### PR TITLE
Moving towards Lilypond-rendered SVGs for phrase display

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ $ npm run-script watch
 ```
 
 [npm]: https://www.npmjs.com/
+
+### Phrase SVG Generation
+
+Building new SVG images for each phrase requires [Lilypond][ly]. The Lilypond
+source files can be found in `assets/ly` and generating SVGs from them is
+automated by a build script in the same directory:
+
+```
+$ cd assets/ly
+$ ./build.sh
+```
+
+[ly]: https://lilypond.org/

--- a/assets/ly/1.ly
+++ b/assets/ly/1.ly
@@ -1,0 +1,37 @@
+\version "2.19.80"
+
+
+phrase = \relative c' {
+
+  \mark "1."
+
+  \acciaccatura c8 e4
+  \acciaccatura c8 e4
+  \acciaccatura c8 e4
+
+}
+
+\score {
+  \defineBarLine ":" #'("" ":" "")
+  \new Staff = "phrase" {
+    \bar ":"
+    \phrase
+    \set Score.repeatCommands = #'(end-repeat)
+  }
+  \layout {
+    \context { \Staff
+      \remove Time_signature_engraver
+      \override BarLine.hair-thickness = #-1
+      \override BarLine.thick-thickness = #-1
+    }
+  }
+}
+\header { tagline = "" }
+\paper {
+  top-margin = 1
+  bottom-margin = 1
+  left-margin = 1
+  right-margin = 1
+  indent = 0
+}
+

--- a/assets/ly/2.ly
+++ b/assets/ly/2.ly
@@ -1,0 +1,36 @@
+\version "2.19.80"
+
+
+phrase = \relative c' {
+
+
+  \acciaccatura c8 \mark "2."
+  e f e4
+
+}
+
+\score {
+  \defineBarLine ":" #'("" ":" "")
+  \new Staff = "phrase" {
+    \bar ":"
+    \phrase
+    \set Score.repeatCommands = #'(end-repeat)
+  }
+  \layout {
+    \context { \Staff
+      \override Clef #'stencil = ##f
+      \remove Time_signature_engraver
+      \override BarLine.hair-thickness = #-1
+      \override BarLine.thick-thickness = #-1
+    }
+  }
+}
+\header { tagline = "" }
+\paper {
+  top-margin = 1
+  bottom-margin = 1
+  left-margin = 1
+  right-margin = 1
+  indent = 0
+}
+

--- a/assets/ly/3.ly
+++ b/assets/ly/3.ly
@@ -1,0 +1,36 @@
+\version "2.19.80"
+
+
+phrase = \relative c' {
+
+
+  r8 \mark "3."
+  e f e
+
+}
+
+\score {
+  \defineBarLine ":" #'("" ":" "")
+  \new Staff = "phrase" {
+    \bar ":"
+    \phrase
+    \set Score.repeatCommands = #'(end-repeat)
+  }
+  \layout {
+    \context { \Staff
+      \override Clef #'stencil = ##f
+      \remove Time_signature_engraver
+      \override BarLine.hair-thickness = #-1
+      \override BarLine.thick-thickness = #-1
+    }
+  }
+}
+\header { tagline = "" }
+\paper {
+  top-margin = 1
+  bottom-margin = 1
+  left-margin = 1
+  right-margin = 1
+  indent = 0
+}
+

--- a/assets/ly/4.ly
+++ b/assets/ly/4.ly
@@ -1,0 +1,36 @@
+\version "2.19.80"
+
+
+phrase = \relative c' {
+
+
+  r8 \mark "4."
+  e f g
+
+}
+
+\score {
+  \defineBarLine ":" #'("" ":" "")
+  \new Staff = "phrase" {
+    \bar ":"
+    \phrase
+    \set Score.repeatCommands = #'(end-repeat)
+  }
+  \layout {
+    \context { \Staff
+      \override Clef #'stencil = ##f
+      \remove Time_signature_engraver
+      \override BarLine.hair-thickness = #-1
+      \override BarLine.thick-thickness = #-1
+    }
+  }
+}
+\header { tagline = "" }
+\paper {
+  top-margin = 1
+  bottom-margin = 1
+  left-margin = 1
+  right-margin = 1
+  indent = 0
+}
+

--- a/assets/ly/5.ly
+++ b/assets/ly/5.ly
@@ -1,0 +1,36 @@
+\version "2.19.80"
+
+
+phrase = \relative c' {
+
+
+  e8 \mark "5."
+  f g r
+
+}
+
+\score {
+  \defineBarLine ":" #'("" ":" "")
+  \new Staff = "phrase" {
+    \bar ":"
+    \phrase
+    \set Score.repeatCommands = #'(end-repeat)
+  }
+  \layout {
+    \context { \Staff
+      \override Clef #'stencil = ##f
+      \remove Time_signature_engraver
+      \override BarLine.hair-thickness = #-1
+      \override BarLine.thick-thickness = #-1
+    }
+  }
+}
+\header { tagline = "" }
+\paper {
+  top-margin = 1
+  bottom-margin = 1
+  left-margin = 1
+  right-margin = 1
+  indent = 0
+}
+

--- a/assets/ly/build.sh
+++ b/assets/ly/build.sh
@@ -1,0 +1,19 @@
+OUT_DIR='../svgs/'
+
+# Make output directory?
+if [ ! -d $OUT_DIR ]; then
+  mkdir -p $OUT_DIR
+fi
+
+# Generate SVGs in output directory
+for f in *.ly; do
+  [ -f "$f" ] || break
+  lilypond --loglevel=BASIC_PROGRESS --output=$OUT_DIR -dpoint-and-click='#f' -dno-print-pages -dpreview -dbackend=svg $f
+done
+
+# Strip *preview* from resulting filenames
+cd $OUT_DIR
+for f in *.svg; do
+  [ -f "$f" ] || break
+  mv $f "`echo $f | sed 's/preview\.//'`"
+done

--- a/assets/phrases.json
+++ b/assets/phrases.json
@@ -61,7 +61,7 @@
     ]
   },
   {
-    "duration": "4n * 3",
+    "duration": "2n",
     "notes": [
       {
         "pitch": "C4",

--- a/assets/svgs/1.svg
+++ b/assets/svgs/1.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="33.21mm" height="15.51mm" viewBox="0.0000 -0.0000 18.8991 8.8244">
+<line transform="translate(0.0000, 6.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="18.8491" y2="-0.0000"/>
+<line transform="translate(0.0000, 5.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="18.8491" y2="-0.0000"/>
+<line transform="translate(0.0000, 4.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="18.8491" y2="-0.0000"/>
+<line transform="translate(0.0000, 3.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="18.8491" y2="-0.0000"/>
+<line transform="translate(0.0000, 2.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="18.8491" y2="-0.0000"/>
+<rect transform="translate(0.0000, 7.7620)" x="12.8203" y="-0.1000" width="1.3768" height="0.2000" ry="0.1000" fill="currentColor"/>
+<rect transform="translate(0.0000, 7.7620)" x="8.6214" y="-0.1000" width="1.3768" height="0.2000" ry="0.1000" fill="currentColor"/>
+<rect transform="translate(0.0000, 7.7620)" x="4.4225" y="-0.1000" width="1.3768" height="0.2000" ry="0.1000" fill="currentColor"/>
+<path transform="translate(4.0650, 4.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(4.0650, 5.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(18.0491, 4.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(18.0491, 5.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(9.7688, 5.0020) scale(0.0028, -0.0028)" d="M-148 -571c-18 0 -32 14 -32 32c0 9 4 17 11 23l357 290c5 5 11 7 18 7c18 0 32 -14 32 -32c0 -9 -4 -17 -11 -23l-357 -290c-5 -5 -11 -7 -18 -7z" fill="currentColor"/>
+<path transform="translate(9.7688, 5.0020) scale(0.0028, -0.0028)" d="M0 0c0 -196 207 -334 207 -530c0 -71 -15 -140 -41 -206c-5 -10 -14 -13 -23 -13c-14 0 -28 10 -28 26c0 2 1 3 1 5c26 59 42 123 42 188c0 101 -90 205 -158 280h-21v250h21z" fill="currentColor"/>
+<rect transform="translate(9.7038, 4.7620)" x="-0.0650" y="0.2000" width="0.1300" height="2.6856" ry="0.0400" fill="currentColor"/>
+<path transform="translate(8.8509, 7.7620) scale(0.0028, -0.0028)" d="M208 139c61 0 117 -33 117 -99c0 -71 -52 -119 -99 -147c-34 -20 -71 -32 -110 -32c-61 0 -116 33 -116 99c0 71 51 119 98 147c34 20 71 32 110 32z" fill="currentColor"/>
+<rect transform="translate(7.8883, 4.7620)" x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<path transform="translate(6.6491, 6.7620) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<path transform="translate(4.6520, 4.7620)" stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5695 3.8940C1.3941 4.2433 2.4212 3.8535 2.8063 3.0450L2.8063 3.0450C2.3786 3.7413 1.3515 4.1311 0.5695 3.8940z"/>
+<path transform="translate(10.8480, 6.7620) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<rect transform="translate(12.0872, 4.7620)" x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<path transform="translate(13.0498, 7.7620) scale(0.0028, -0.0028)" d="M208 139c61 0 117 -33 117 -99c0 -71 -52 -119 -99 -147c-34 -20 -71 -32 -110 -32c-61 0 -116 33 -116 99c0 71 51 119 98 147c34 20 71 32 110 32z" fill="currentColor"/>
+<rect transform="translate(13.9027, 4.7620)" x="-0.0650" y="0.2000" width="0.1300" height="2.6856" ry="0.0400" fill="currentColor"/>
+<path transform="translate(13.9677, 5.0020) scale(0.0028, -0.0028)" d="M-148 -571c-18 0 -32 14 -32 32c0 9 4 17 11 23l357 290c5 5 11 7 18 7c18 0 32 -14 32 -32c0 -9 -4 -17 -11 -23l-357 -290c-5 -5 -11 -7 -18 -7z" fill="currentColor"/>
+<path transform="translate(13.9677, 5.0020) scale(0.0028, -0.0028)" d="M0 0c0 -196 207 -334 207 -530c0 -71 -15 -140 -41 -206c-5 -10 -14 -13 -23 -13c-14 0 -28 10 -28 26c0 2 1 3 1 5c26 59 42 123 42 188c0 101 -90 205 -158 280h-21v250h21z" fill="currentColor"/>
+<path transform="translate(13.0498, 4.7620)" stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5695 3.8940C1.3941 4.2433 2.4212 3.8535 2.8063 3.0450L2.8063 3.0450C2.3786 3.7413 1.3515 4.1311 0.5695 3.8940z"/>
+<path transform="translate(8.8509, 4.7620)" stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5695 3.8940C1.3941 4.2433 2.4212 3.8535 2.8063 3.0450L2.8063 3.0450C2.3786 3.7413 1.3515 4.1311 0.5695 3.8940z"/>
+<text transform="translate(3.2486, 1.8779)" font-family="serif" font-size="2.7719" text-anchor="start" fill="currentColor">
+<tspan>
+1.</tspan>
+</text>
+<path transform="translate(5.5699, 5.0020) scale(0.0028, -0.0028)" d="M-148 -571c-18 0 -32 14 -32 32c0 9 4 17 11 23l357 290c5 5 11 7 18 7c18 0 32 -14 32 -32c0 -9 -4 -17 -11 -23l-357 -290c-5 -5 -11 -7 -18 -7z" fill="currentColor"/>
+<path transform="translate(5.5699, 5.0020) scale(0.0028, -0.0028)" d="M0 0c0 -196 207 -334 207 -530c0 -71 -15 -140 -41 -206c-5 -10 -14 -13 -23 -13c-14 0 -28 10 -28 26c0 2 1 3 1 5c26 59 42 123 42 188c0 101 -90 205 -158 280h-21v250h21z" fill="currentColor"/>
+<rect transform="translate(5.5049, 4.7620)" x="-0.0650" y="0.2000" width="0.1300" height="2.6856" ry="0.0400" fill="currentColor"/>
+<path transform="translate(0.8000, 5.7620) scale(0.0040, -0.0040)" d="M376 262c4 0 9 1 13 1c155 0 256 -128 256 -261c0 -76 -33 -154 -107 -210c-22 -17 -47 -28 -73 -36c3 -35 5 -70 5 -105c0 -19 -1 -39 -2 -58c-7 -120 -90 -228 -208 -228c-108 0 -195 88 -195 197c0 58 53 103 112 103c54 0 95 -47 95 -103c0 -52 -43 -95 -95 -95
+c-11 0 -21 2 -31 6c26 -39 68 -65 117 -65c96 0 157 92 163 191c1 18 2 37 2 55c0 31 -1 61 -4 92c-29 -5 -58 -8 -89 -8c-188 0 -333 172 -333 374c0 177 131 306 248 441c-19 62 -37 125 -45 190c-6 52 -7 104 -7 156c0 115 55 224 149 292c3 2 7 3 10 3c4 0 7 0 10 -3
+c71 -84 133 -245 133 -358c0 -143 -86 -255 -180 -364c21 -68 39 -138 56 -207zM461 -203c68 24 113 95 113 164c0 90 -66 179 -173 190c24 -116 46 -231 60 -354zM74 28c0 -135 129 -247 264 -247c28 0 55 2 82 6c-14 127 -37 245 -63 364c-79 -8 -124 -61 -124 -119
+c0 -44 25 -91 81 -123c5 -5 7 -10 7 -15c0 -11 -10 -22 -22 -22c-3 0 -6 1 -9 2c-80 43 -117 115 -117 185c0 88 58 174 160 197c-14 58 -29 117 -46 175c-107 -121 -213 -243 -213 -403zM408 1045c-99 -48 -162 -149 -162 -259c0 -74 18 -133 36 -194
+c80 97 146 198 146 324c0 55 -4 79 -20 129z" fill="currentColor"/>
+<path transform="translate(4.6520, 7.7620) scale(0.0028, -0.0028)" d="M208 139c61 0 117 -33 117 -99c0 -71 -52 -119 -99 -147c-34 -20 -71 -32 -110 -32c-61 0 -116 33 -116 99c0 71 51 119 98 147c34 20 71 32 110 32z" fill="currentColor"/>
+<rect transform="translate(16.2861, 4.7620)" x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<path transform="translate(15.0469, 6.7620) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+</svg>

--- a/assets/svgs/2.svg
+++ b/assets/svgs/2.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="22.42mm" height="15.41mm" viewBox="0.0000 -0.0000 12.7597 8.7663">
+<line transform="translate(0.0000, 6.7279)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.7097" y2="-0.0000"/>
+<line transform="translate(0.0000, 5.7279)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.7097" y2="-0.0000"/>
+<line transform="translate(0.0000, 4.7279)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.7097" y2="-0.0000"/>
+<line transform="translate(0.0000, 3.7279)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.7097" y2="-0.0000"/>
+<line transform="translate(0.0000, 2.7279)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.7097" y2="-0.0000"/>
+<rect transform="translate(0.0000, 7.7279)" x="1.1705" y="-0.1000" width="1.3768" height="0.2000" ry="0.1000" fill="currentColor"/>
+<path transform="translate(11.9097, 4.2279) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(11.9097, 5.2279) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(0.0000, 4.2279) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(0.0000, 5.2279) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<rect transform="translate(9.4447, 4.7279)" x="-0.0650" y="-1.5000" width="0.1300" height="3.3139" ry="0.0400" fill="currentColor"/>
+<path transform="translate(8.2055, 6.7279) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<path transform="translate(1.4000, 7.7279) scale(0.0028, -0.0028)" d="M208 139c61 0 117 -33 117 -99c0 -71 -52 -119 -99 -147c-34 -20 -71 -32 -110 -32c-61 0 -116 33 -116 99c0 71 51 119 98 147c34 20 71 32 110 32z" fill="currentColor"/>
+<path transform="translate(1.4000, 4.7279)" stroke-width="0.0800" stroke-linejoin="round" stroke-linecap="round" stroke="currentColor" fill="currentColor" d="M0.5790 3.8940C1.3610 4.1983 2.2844 3.8142 2.6198 3.0450L2.6198 3.0450C2.2383 3.7034 1.3149 4.0876 0.5790 3.8940z"/>
+<rect transform="translate(2.2529, 4.7279)" x="-0.0650" y="0.2000" width="0.1300" height="2.6856" ry="0.0400" fill="currentColor"/>
+<path transform="translate(2.3179, 4.9679) scale(0.0028, -0.0028)" d="M-148 -571c-18 0 -32 14 -32 32c0 9 4 17 11 23l357 290c5 5 11 7 18 7c18 0 32 -14 32 -32c0 -9 -4 -17 -11 -23l-357 -290c-5 -5 -11 -7 -18 -7z" fill="currentColor"/>
+<path transform="translate(2.3179, 4.9679) scale(0.0028, -0.0028)" d="M0 0c0 -196 207 -334 207 -530c0 -71 -15 -140 -41 -206c-5 -10 -14 -13 -23 -13c-14 0 -28 10 -28 26c0 2 1 3 1 5c26 59 42 123 42 188c0 101 -90 205 -158 280h-21v250h21z" fill="currentColor"/>
+<polygon transform="translate(4.3713, 3.7279)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="2.5942 -0.3900 2.5942 0.0100 0.0400 0.2000 0.0400 -0.2000"/>
+<path transform="translate(3.1971, 6.7279) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<text transform="translate(1.6462, 1.8437)" font-family="serif" font-size="2.7719" text-anchor="start" fill="currentColor">
+<tspan>
+2.</tspan>
+</text>
+<rect transform="translate(4.4363, 4.7279)" x="-0.0650" y="-1.0047" width="0.1300" height="2.8186" ry="0.0400" fill="currentColor"/>
+<rect transform="translate(6.9405, 4.7279)" x="-0.0650" y="-1.1853" width="0.1300" height="2.4992" ry="0.0400" fill="currentColor"/>
+<path transform="translate(5.7013, 6.2279) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+</svg>

--- a/assets/svgs/3.svg
+++ b/assets/svgs/3.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="22.87mm" height="12.84mm" viewBox="0.0000 -0.0000 13.0126 7.3070">
+<line transform="translate(0.0000, 6.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<line transform="translate(0.0000, 5.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<line transform="translate(0.0000, 4.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<line transform="translate(0.0000, 3.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<line transform="translate(0.0000, 2.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<path transform="translate(12.1626, 4.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(12.1626, 5.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(0.0000, 4.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(0.0000, 5.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<polygon transform="translate(5.8242, 3.5720)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="5.0984 -0.2000 5.0984 0.2000 0.0400 0.2000 0.0400 -0.2000"/>
+<path transform="translate(1.7500, 4.7620) scale(0.0040, -0.0040)" d="M72 -250l117 326c-34 -12 -69 -22 -105 -22c-46 0 -87 33 -87 79c0 40 33 72 73 72c25 0 48 -15 56 -39c10 -28 6 -59 35 -59c16 0 54 48 61 63c6 12 23 12 28 0l-123 -420c-8 -7 -17 -10 -27 -10s-20 3 -28 10z" fill="currentColor"/>
+<path transform="translate(9.6584, 6.7620) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<rect transform="translate(10.8976, 4.7620)" x="-0.0650" y="-1.1900" width="0.1300" height="3.0039" ry="0.0400" fill="currentColor"/>
+<path transform="translate(4.6500, 6.7620) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<text transform="translate(3.1086, 1.8779)" font-family="serif" font-size="2.7719" text-anchor="start" fill="currentColor">
+<tspan>
+3.</tspan>
+</text>
+<rect transform="translate(5.8892, 4.7620)" x="-0.0650" y="-1.1900" width="0.1300" height="3.0039" ry="0.0400" fill="currentColor"/>
+<path transform="translate(7.1542, 6.2620) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<rect transform="translate(8.3934, 4.7620)" x="-0.0650" y="-1.1900" width="0.1300" height="2.5039" ry="0.0400" fill="currentColor"/>
+</svg>

--- a/assets/svgs/4.svg
+++ b/assets/svgs/4.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="22.87mm" height="12.84mm" viewBox="0.0000 -0.0000 13.0126 7.3070">
+<line transform="translate(0.0000, 6.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<line transform="translate(0.0000, 5.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<line transform="translate(0.0000, 4.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<line transform="translate(0.0000, 3.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<line transform="translate(0.0000, 2.7620)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.9626" y2="-0.0000"/>
+<path transform="translate(12.1626, 4.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(12.1626, 5.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(0.0000, 4.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(0.0000, 5.2620) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<polygon transform="translate(5.8242, 3.5720)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="5.0984 -0.8200 5.0984 -0.4200 0.0400 0.2000 0.0400 -0.2000"/>
+<path transform="translate(1.7500, 4.7620) scale(0.0040, -0.0040)" d="M72 -250l117 326c-34 -12 -69 -22 -105 -22c-46 0 -87 33 -87 79c0 40 33 72 73 72c25 0 48 -15 56 -39c10 -28 6 -59 35 -59c16 0 54 48 61 63c6 12 23 12 28 0l-123 -420c-8 -7 -17 -10 -27 -10s-20 3 -28 10z" fill="currentColor"/>
+<path transform="translate(9.6584, 5.7620) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<rect transform="translate(10.8976, 4.7620)" x="-0.0650" y="-1.8022" width="0.1300" height="2.6161" ry="0.0400" fill="currentColor"/>
+<path transform="translate(4.6500, 6.7620) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<text transform="translate(3.1086, 1.8779)" font-family="serif" font-size="2.7719" text-anchor="start" fill="currentColor">
+<tspan>
+4.</tspan>
+</text>
+<rect transform="translate(5.8892, 4.7620)" x="-0.0650" y="-1.1978" width="0.1300" height="3.0117" ry="0.0400" fill="currentColor"/>
+<path transform="translate(7.1542, 6.2620) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<rect transform="translate(8.3934, 4.7620)" x="-0.0650" y="-1.5000" width="0.1300" height="2.8139" ry="0.0400" fill="currentColor"/>
+</svg>

--- a/assets/svgs/5.svg
+++ b/assets/svgs/5.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.2" width="22.33mm" height="12.72mm" viewBox="0.0000 -0.0000 12.7084 7.2387">
+<line transform="translate(0.0000, 6.6937)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.6584" y2="-0.0000"/>
+<line transform="translate(0.0000, 5.6937)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.6584" y2="-0.0000"/>
+<line transform="translate(0.0000, 4.6937)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.6584" y2="-0.0000"/>
+<line transform="translate(0.0000, 3.6937)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.6584" y2="-0.0000"/>
+<line transform="translate(0.0000, 2.6937)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.1000" stroke="currentColor" x1="0.0500" y1="-0.0000" x2="12.6584" y2="-0.0000"/>
+<path transform="translate(11.8584, 4.1937) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(11.8584, 5.1937) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(0.0000, 4.1937) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<path transform="translate(0.0000, 5.1937) scale(0.0040, -0.0040)" d="M0 0c0 31 25 56 56 56s56 -25 56 -56s-25 -56 -56 -56s-56 25 -56 56z" fill="currentColor"/>
+<polygon transform="translate(2.9242, 3.5037)" stroke-linejoin="round" stroke-linecap="round" stroke-width="0.0800" fill="currentColor" stroke="currentColor" points="5.4942 -0.8200 5.4942 -0.4200 0.0400 0.2000 0.0400 -0.2000"/>
+<rect transform="translate(8.3934, 4.6937)" x="-0.0650" y="-1.8027" width="0.1300" height="2.6166" ry="0.0400" fill="currentColor"/>
+<path transform="translate(1.7500, 6.6937) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<path transform="translate(9.6584, 4.6937) scale(0.0040, -0.0040)" d="M72 -250l117 326c-34 -12 -69 -22 -105 -22c-46 0 -87 33 -87 79c0 40 33 72 73 72c25 0 48 -15 56 -39c10 -28 6 -59 35 -59c16 0 54 48 61 63c6 12 23 12 28 0l-123 -420c-8 -7 -17 -10 -27 -10s-20 3 -28 10z" fill="currentColor"/>
+<rect transform="translate(2.9892, 4.6937)" x="-0.0650" y="-1.1973" width="0.1300" height="3.0112" ry="0.0400" fill="currentColor"/>
+<path transform="translate(4.6500, 6.1937) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+<text transform="translate(3.1086, 1.8096)" font-family="serif" font-size="2.7719" text-anchor="start" fill="currentColor">
+<tspan>
+5.</tspan>
+</text>
+<rect transform="translate(5.8892, 4.6937)" x="-0.0650" y="-1.5222" width="0.1300" height="2.8361" ry="0.0400" fill="currentColor"/>
+<path transform="translate(7.1542, 5.6937) scale(0.0040, -0.0040)" d="M218 136c55 0 108 -28 108 -89c0 -71 -55 -121 -102 -149c-35 -21 -75 -34 -116 -34c-55 0 -108 28 -108 89c0 71 55 121 102 149c35 21 75 34 116 34z" fill="currentColor"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
   <div class="panel pattern-view-container">
     <image class="pattern-view" src="assets/images/Sco1.png" data-pattern=0></image>
   </div>
+  <div class="panel svg-panel">
+    <image class="svg-view" src="assets/svgs/1.svg" preserveAspectRatio="xMidYMid meet"></image>
+  </div>
   <div class="panel controls">
     <button class="backward">Previous</button>
     <button class="play">Play</button>

--- a/js/main.js
+++ b/js/main.js
@@ -82,7 +82,7 @@
       Tone.Transport.scheduleOnce(function(time){
         //re-enable button slightly ahead of end of phrase
         playButton.dataset.scheduled = false;
-      }, `@4n + (${phrases[phraseNum].duration})/4`);
+      }, `@4n + (${phrases[phraseNum].duration})/2`);
       parts[phraseNum].start('@4n').stop(`@4n + ${phrases[phraseNum].duration}`);
       playButton.dataset.scheduled = true;
     }

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,7 @@
   const totalPatterns = 53;
 
   const patternView = document.querySelector('.pattern-view');
+  const svgView = document.querySelector('.svg-view');
   const forwardButton = document.querySelector('.forward');
   const backwardButton = document.querySelector('.backward');
   const ostinatoButton = document.querySelector('.ostinato');
@@ -15,6 +16,7 @@
     const pattern = (parseInt(patternView.dataset.pattern, 10) + 1) % totalPatterns;
     patternView.dataset.pattern = pattern;
     patternView.src = `assets/images/Sco${pattern+1}.png`;
+    svgView.src = `assets/svgs/${pattern+1}.svg`;
   };
 
   backwardButton.onclick = () => {
@@ -22,6 +24,7 @@
     const pattern = (n-1 >= 0) ? n-1 : totalPatterns-1;
     patternView.dataset.pattern = pattern;
     patternView.src = `assets/images/Sco${pattern+1}.png`;
+    svgView.src = `assets/svgs/${pattern+1}.svg`;
   };
 
   const ostinato = new Tone.Synth({

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   },
   "homepage": "https://github.com/loyola-university-tech-ensemble/InC_WebApp#readme",
   "dependencies": {
-    "tone": "^0.11.11",
-    "vexflow": "^1.2.84"
+    "tone": "^0.11.11"
   },
   "devDependencies": {
     "browserify": "^14.5.0",

--- a/style/main.css
+++ b/style/main.css
@@ -1,14 +1,38 @@
 body {
-  width: 50%;
-  margin: 15px auto;
+  margin-top: 15px;
+  margin-bottom: 15px;
   background-color: #232630;
   color: #f8efff;
   font-family: Helvetica, Arial, sans-serif;
 }
 
+@media (min-width: 800px) {
+  body {
+    width: 50%;
+    margin: 15px auto;
+  }
+}
+
 header {
   font-size: 26px;
   font-weight: 300;
+}
+
+button {
+  padding: 10px 15px;
+  border: none;
+  border-radius: 2px;
+  color: white;
+  background: #5398af;
+  font-size: 14px;
+}
+
+button:focus {
+  outline: none;
+}
+
+#vex-view {
+  background: white;
 }
 
 .panel {
@@ -23,4 +47,19 @@ header {
 
 .pattern-view {
   min-height: 150px;
+}
+
+.svg-view {
+  background: white;
+  padding: 15px;
+  height: 100px;
+}
+
+.panel.controls {
+  display: flex;
+  justify-content: space-around;
+}
+
+button[data-scheduled="true"] {
+  background: #5c6d7b;
 }


### PR DESCRIPTION
Vexflow rendering is unreliable and slow, and we can get the same versatility by pre-rendering phrases as SVG using Lilypond. This will result in smaller file sizes than PNGs and enable CSS animations just like Vexflow would have, all with one less dependency.